### PR TITLE
CMake 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,94 @@
+cmake_minimum_required(VERSION 2.8.7)
+project(libogg)
+
+# Required modules
+include(GNUInstallDirs)
+include(CheckIncludeFiles)
+
+# Build options
+option(BUILD_SHARED_LIBS "Build shared library" OFF)
+if(APPLE)
+    option(BUILD_FRAMEWORK "Build Framework bundle for OSX" OFF)
+endif()
+
+# Extract project version from configure.ac
+file(READ configure.ac CONFIGURE_AC_CONTENTS)
+string(REGEX MATCH "AC_INIT\\(\\[libogg\\],\\[([0-9]*).([0-9]*).([0-9]*)" DUMMY ${CONFIGURE_AC_CONTENTS})
+set(PROJECT_VERSION_MAJOR ${CMAKE_MATCH_1})
+set(PROJECT_VERSION_MINOR ${CMAKE_MATCH_2})
+set(PROJECT_VERSION_PATCH ${CMAKE_MATCH_3})
+set(PROJECT_VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH})
+
+# Extract so library version from configure.ac
+string(REGEX MATCH "LIB_AGE=([0-9]*)" DUMMY ${CONFIGURE_AC_CONTENTS})
+set(LIB_AGE ${CMAKE_MATCH_1})
+string(REGEX MATCH "LIB_REVISION=([0-9]*)" DUMMY ${CONFIGURE_AC_CONTENTS})
+set(LIB_REVISION ${CMAKE_MATCH_1})
+
+message(STATUS "Configuring ${PROJECT_NAME} ${PROJECT_VERSION}")
+message(STATUS "Shared library version 0.${LIB_AGE}.${LIB_REVISION}")
+
+# Configure config_type.h
+check_include_files(inttypes.h INCLUDE_INTTYPES_H)
+check_include_files(stdint.h INCLUDE_STDINT_H)
+check_include_files(sys/types.h INCLUDE_SYS_TYPES_H)
+
+set(SIZE16 int16_t)
+set(USIZE16 uint16_t)
+set(SIZE32 int32_t)
+set(USIZE32 uint32_t)
+set(SIZE64 int64_t)
+
+configure_file(include/ogg/config_types.h.in include/ogg/config_types.h @ONLY)
+
+set(OGG_HEADERS
+    include/ogg/ogg.h
+    include/ogg/os_types.h
+)
+
+set(OGG_SOURCES
+    src/bitwise.c
+    src/framing.c
+)
+
+if(MSVC)
+    list(APPEND OGG_SOURCES win32/ogg.def)
+endif()
+
+if(BUILD_FRAMEWORK)
+    set(BUILD_SHARED_LIBS TRUE)
+endif()
+
+include_directories(include)
+add_library(ogg ${OGG_HEADERS} ${OGG_SOURCES})
+set_target_properties(ogg PROPERTIES SOVERSION "0.${LIB_AGE}.${LIB_REVISION}")
+
+if(BUILD_FRAMEWORK)
+    set_target_properties(ogg PROPERTIES
+        FRAMEWORK TRUE
+        FRAMEWORK_VERSION ${PROJECT_VERSION}
+        MACOSX_FRAMEWORK_IDENTIFIER org.xiph.ogg
+        MACOSX_FRAMEWORK_SHORT_VERSION_STRING ${PROJECT_VERSION}
+        MACOSX_FRAMEWORK_BUNDLE_VERSION ${PROJECT_VERSION}
+        XCODE_ATTRIBUTE_INSTALL_PATH "@rpath"
+        PUBLIC_HEADER "${OGG_HEADERS}"
+        OUTPUT_NAME Ogg
+    )
+endif()
+
+# Configure pkg-config files
+function(configure_pkg_config_file pkg_config_file_in)
+    set(prefix ${CMAKE_INSTALL_PREFIX})
+    set(exec_prefix ${CMAKE_INSTALL_FULL_BINDIR})
+    set(libdir ${CMAKE_INSTALL_FULL_LIBDIR})
+    set(includedir ${CMAKE_INSTALL_FULL_INCLUDEDIR})
+    set(VERSION ${PROJECT_VERSION})
+    string(REPLACE ".in" "" pkg_config_file ${pkg_config_file_in})
+    configure_file(${pkg_config_file_in} ${pkg_config_file} @ONLY)
+endfunction()
+
+configure_pkg_config_file(ogg.pc.in)
+
+install(FILES include/ogg/ogg.h include/ogg/os_types.h include/ogg/config_types.h DESTINATION ${CMAKE_INSTALL_FULL_INCLUDEDIR})
+install(TARGETS ogg RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} FRAMEWORK DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(FILES ogg.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/README.md
+++ b/README.md
@@ -86,6 +86,39 @@ your system:
 (Build instructions for Ogg codecs such as vorbis are similar and may
 be found in those source modules' README files)
 
+## Building with CMake ##
+
+Ogg supports building using [CMake](http://www.cmake.org/). CMake is a meta build system that generates native projects for each platform.
+To generate projects just run cmake replacing `YOUR-PROJECT-GENERATOR` with a proper generator from a list [here](http://www.cmake.org/cmake/help/v3.2/manual/cmake-generators.7.html):
+
+    cmake -G YOUR-PROJECT-GENERATOR .
+
+Note that by default cmake generates projects that will build static libraries.
+To generate projects that will build dynamic library use `BUILD_SHARED_LIBS` option like this:
+
+    cmake -G YOUR-PROJECT-GENERATOR -DBUILD_SHARED_LIBS=1 .
+
+After projects are generated use them as usual
+
+#### Building on Windows ####
+
+Use proper generator for your Visual Studio version like:
+
+    cmake -G "Visual Studio 12 2013" .
+
+#### Building on Mac OS X ####
+
+Use Xcode generator. To build framework run:
+
+    cmake -G Xcode -DBUILD_FRAMEWORK=1 .
+
+#### Building on Linux ####
+
+Use Makefile generator which is default one.
+
+    cmake .
+    make
+
 ## License ##
 
 THIS FILE IS PART OF THE OggVorbis SOFTWARE CODEC SOURCE CODE.


### PR DESCRIPTION
Let me explain the reasons behind this pull request.

The truth is that the majority of open source projects have unix roots and thus use makefiles as their main build system. Makefiles are somewhat ok for OS X (but Xcode is still better) and totally unacceptable on Windows. Eventually almost all open source project eventually add `win32` and `macosx` folders where handcrafted Visual Studio and Xcode projects are located. Two main common problems of this approach are:

 - Project explosion. You need a project for each Visual Studio version for each build configuration. It's really hard to maintain.
 - Hand-crafted projects are often remain unmaintained for years (current Xcode project was last updated 6 years ago) and are useless anyway.

Here is where CMake comes to help. It solves two mentioned problems and it's really well known tool. It's being successfully used in such big C/C++ projects like LLVM. Even Microsoft itself uses it for their own open source C/C++ projects like [coreclr](https://github.com/dotnet/coreclr). And almost all C/C++ programmers already know CMake and have it installed anyway.

So please take a look through the code and feel free to express and thoughts and complains. I'm not an autotools expert so I could missed something. For example I still don't understand purpose of `ogg-uninstalled.pc.in` file. Documentation installing is also not implemented yet. Anyway I'm here to fix anything you find suspicious.

Also I would be really happy to see hand-crafted projects to be removed eventually but it's probably too early to think about that and not up to me to decide at all.




