### PR TITLE
Remove Mac OS 9 support

### DIFF
--- a/include/ogg/os_types.h
+++ b/include/ogg/os_types.h
@@ -67,15 +67,6 @@
 #    endif
 #  endif
 
-#elif defined(__MACOS__)
-
-#  include <sys/types.h>
-   typedef SInt16 ogg_int16_t;
-   typedef UInt16 ogg_uint16_t;
-   typedef SInt32 ogg_int32_t;
-   typedef UInt32 ogg_uint32_t;
-   typedef SInt64 ogg_int64_t;
-
 #elif (defined(__APPLE__) && defined(__MACH__)) /* MacOS X Framework build */
 
 #  include <inttypes.h>


### PR DESCRIPTION
As was noted in this [pull request](https://github.com/xiph/vorbis/pull/2) support for classic Mac OS is really not needed anymore.