### PR TITLE
 On branch master

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ function(configure_pkg_config_file pkg_config_file_in)
     set(includedir ${CMAKE_INSTALL_FULL_INCLUDEDIR})
     set(VERSION ${PROJECT_VERSION})
     string(REPLACE ".in" "" pkg_config_file ${pkg_config_file_in})
-    configure_file(${pkg_config_file_in} ${pkg_config_file} @ONLY)
+    configure_file(${pkg_config_file_in} ${CMAKE_CURRENT_SOURCE_DIR}/${pkg_config_file} @ONLY)
 endfunction()
 
 message(STATUS "Configuring ${PROJECT_NAME} ${PROJECT_VERSION}")
@@ -59,7 +59,7 @@ set(SIZE32 int32_t)
 set(USIZE32 uint32_t)
 set(SIZE64 int64_t)
 
-configure_file(include/ogg/config_types.h.in include/ogg/config_types.h @ONLY)
+configure_file(include/ogg/config_types.h.in ${CMAKE_CURRENT_SOURCE_DIR}/include/ogg/config_types.h @ONLY)
 
 set(OGG_HEADERS
     include/ogg/ogg.h


### PR DESCRIPTION
Minor change to CMakeLists.txt to make sure config_types.h and ogg.pc get
generated in the source tree as expected. Tested on OSX Yosemite, Ubuntu 64 bit 15.04 and MSVC 2015 RC.