### PR TITLE
add configure option to disable checks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -153,6 +153,12 @@ fi
 dnl Checks for library functions.
 AC_FUNC_MEMCMP
 
+AC_ARG_ENABLE([extra-programs],
+    [AS_HELP_STRING([--disable-extra-programs], [Do not build extra programs (demo and tests)])],,
+    [enable_extra_programs=yes])
+
+AM_CONDITIONAL([EXTRA_PROGRAMS], [test "$enable_extra_programs" = "yes"])
+
 dnl Make substitutions
 
 AC_SUBST(LIBTOOL_DEPS)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,6 +7,7 @@ lib_LTLIBRARIES = libogg.la
 libogg_la_SOURCES = framing.c bitwise.c
 libogg_la_LDFLAGS = -no-undefined -version-info @LIB_CURRENT@:@LIB_REVISION@:@LIB_AGE@
 
+if EXTRA_PROGRAMS
 # build and run the self tests on 'make check'
 
 noinst_PROGRAMS = test_bitwise test_framing
@@ -20,6 +21,7 @@ test_framing_CFLAGS = -D_V_SELFTEST
 check: $(noinst_PROGRAMS)
 	./test_bitwise$(EXEEXT)
 	./test_framing$(EXEEXT)
+endif
 
 debug:
 	$(MAKE) all CFLAGS="@DEBUG@"


### PR DESCRIPTION
some embedded platforms (such as esp8266) don't like these check
programs...
