### PR TITLE
Add CMake as buildsystem to AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,13 +7,28 @@ platform:
 - Win32
 - x64
 
-build:
-  project: win32\VS2015\libogg_static.sln
-  parallel: true
-  verbosity: minimal
+environment:
+  matrix:
+  - BUILD_SYSTEM: MSVC
+  - BUILD_SYSTEM: CMAKE
+
+
+build_script:
+  - if "%BUILD_SYSTEM%" == "MSVC" (
+      msbuild "%APPVEYOR_BUILD_FOLDER%\win32\VS2015\libogg_static.sln" /m /v:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /property:Configuration=%CONFIGURATION%;Platform=%PLATFORM%
+    )
+  - if "%BUILD_SYSTEM%" == "CMAKE" (
+      mkdir "%APPVEYOR_BUILD_FOLDER%\build" &&
+      pushd "%APPVEYOR_BUILD_FOLDER%\build" &&
+      cmake -A "%PLATFORM%" -G "Visual Studio 14 2015" .. &&
+      cmake --build . --config "%CONFIGURATION%" -- /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" &&
+      popd
+    )
 
 after_build:
-- cmd: 7z a ogg.zip win32\VS2015\%PLATFORM%\%CONFIGURATION%\libogg_static.lib include\ogg\*.h
+  - if "%BUILD_SYSTEM%" == "MSVC" (
+      7z a ogg.zip win32\VS2015\%PLATFORM%\%CONFIGURATION%\libogg_static.lib include\ogg\*.h
+    )
 
 artifacts:
 - path: ogg.zip


### PR DESCRIPTION
This PR should enable building both Visual Studio and CMake on AppVeyor. This should enable pulling CMake relevant PRs with more confidence.
