### PR TITLE
Add CMake as buildsystem to Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,21 @@
 language: c
+
+env:
+  - BUILD_SYSTEM=AUTOTOOLS
+  - BUILD_SYSTEM=CMAKE
+
 script:
-  - ./autogen.sh
-  - ./configure
-  - make distcheck
+  - >
+    if [[ "$BUILD_SYSTEM" == "AUTOTOOLS" ]] ; then
+      ./autogen.sh
+      ./configure
+      make distcheck
+    fi
+  - >
+    if [[ "$BUILD_SYSTEM" == "CMAKE" ]] ; then
+      mkdir build
+      pushd build
+      cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release ..
+      cmake --build .
+      popd
+    fi


### PR DESCRIPTION
This PR should enable building both Autotools and CMake on Travis-CI.  This should enable pulling CMake relevant PRs with more confidence.
