### PR TITLE
Add Cmake config package generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,10 @@
-cmake_minimum_required(VERSION 2.8.7)
-project(libogg)
+cmake_minimum_required(VERSION 2.8.12)
+project(ogg)
 
 # Required modules
 include(GNUInstallDirs)
 include(CheckIncludeFiles)
+include(CMakePackageConfigHelpers)
 
 # Build options
 option(BUILD_SHARED_LIBS "Build shared library" OFF)
@@ -80,8 +81,11 @@ if(BUILD_FRAMEWORK)
     set(BUILD_SHARED_LIBS TRUE)
 endif()
 
-include_directories(include)
 add_library(ogg ${OGG_HEADERS} ${OGG_SOURCES})
+target_include_directories(ogg PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
 
 get_version_info(OGG_VERSION_INFO "LIB_CURRENT" "LIB_AGE" "LIB_REVISION")
 set_target_properties(
@@ -104,7 +108,10 @@ endif()
 
 configure_pkg_config_file(ogg.pc.in)
 
+write_basic_package_version_file(OggConfigVersion.cmake COMPATIBILITY SameMajorVersion)
+
 install(TARGETS ogg
+    EXPORT OggTargets
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -112,3 +119,16 @@ install(TARGETS ogg
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ogg
 )
 install(FILES ogg.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+if (UNIX)
+    set(CMAKE_INSTALL_PACKAGEDIR ${CMAKE_INSTALL_LIBDIR}/cmake/ogg)
+elseif(WIN32)
+    set(CMAKE_INSTALL_PACKAGEDIR ${CMAKE_INSTALL_PREFIX}/cmake)
+endif()
+if (CMAKE_INSTALL_PACKAGEDIR)
+    install(EXPORT OggTargets DESTINATION ${CMAKE_INSTALL_PACKAGEDIR})
+    install(FILES
+        OggConfig.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/OggConfigVersion.cmake
+        DESTINATION ${CMAKE_INSTALL_PACKAGEDIR}
+    )
+endif ()

--- a/OggConfig.cmake
+++ b/OggConfig.cmake
@@ -1,0 +1,2 @@
+include(${CMAKE_CURRENT_LIST_DIR}/OggTargets.cmake)
+


### PR DESCRIPTION
# Description

This patch greatly simpifies using ogg library in other CMake-based projects.

After installing CMake build, any call to `find_package` from CMake scripts will succeed.

# Usage example

```
find_package(Ogg 1.3)
if (Ogg_FOUND)
  target_link_libraries(my_program ogg)
endif ()
```

That's all. No need to write your own FindOgg.cmake module, add include dirs etc...

This works even under Windows. Default install location is '%PROGRAMFILES%\ogg' and CMake will find it automatically. If you installed the library elsewhere, use the `Ogg_DIR` variable to specify the path to the installation.

# Other changes

* Project renamed from `libogg` to `ogg` to configure correct install location under Windows.
* Required CMake version bumped up to 2.8.12 to support `target_include_directories`.