### PR TITLE
missing exports from ogg.def

### DIFF
--- a/win32/ogg.def
+++ b/win32/ogg.def
@@ -63,6 +63,8 @@ ogg_stream_reset
 ogg_stream_reset_serialno
 ogg_stream_destroy
 ogg_stream_eos
+ogg_stream_pageout_fill
+ogg_stream_flush_fill
 ;
 ogg_page_checksum_set
 ogg_page_version


### PR DESCRIPTION
I created a branch with only the change for the missing functions. I hope this can be merged to xiph/ogg/master without problems. I couldn't figure out how to do it another way. Pull request #30 would be obsolete with this one.