### PR TITLE
Include CMake build scripts in release archives

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,7 @@ pkgconfig_DATA = ogg.pc
 EXTRA_DIST = README.md AUTHORS CHANGES COPYING \
 	libogg.spec libogg.spec.in \
 	ogg.m4 ogg.pc.in ogg-uninstalled.pc.in \
-	macosx win32
+	macosx win32 CMakeLists.txt
 
 dist-hook:
 	for item in $(EXTRA_DIST); do \


### PR DESCRIPTION
Fixes xiph/ogg#35 for future releases.