### PR TITLE
cmake: Remove unnessessary variables from configure_file() command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ function(configure_pkg_config_file pkg_config_file_in)
     set(includedir ${CMAKE_INSTALL_FULL_INCLUDEDIR})
     set(VERSION ${PROJECT_VERSION})
     string(REPLACE ".in" "" pkg_config_file ${pkg_config_file_in})
-    configure_file(${pkg_config_file_in} ${CMAKE_CURRENT_BINARY_DIR}/${pkg_config_file} @ONLY)
+    configure_file(${pkg_config_file_in} ${pkg_config_file} @ONLY)
 endfunction()
 
 message(STATUS "Configuring ${PROJECT_NAME} ${PROJECT_VERSION}")
@@ -59,7 +59,7 @@ set(SIZE32 int32_t)
 set(USIZE32 uint32_t)
 set(SIZE64 int64_t)
 
-configure_file(include/ogg/config_types.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/ogg/config_types.h @ONLY)
+configure_file(include/ogg/config_types.h.in include/ogg/config_types.h @ONLY)
 
 set(OGG_HEADERS
     ${CMAKE_CURRENT_BINARY_DIR}/include/ogg/config_types.h


### PR DESCRIPTION
Just cleanup.

Output path is relative to build directory anyway according
to documentation.

Related to #9.