### PR TITLE
Fix ogg.def file

### DIFF
--- a/win32/ogg.def
+++ b/win32/ogg.def
@@ -2,7 +2,6 @@
 ; ogg.def
 ; List of exported functions for Windows builds.
 ;
-LIBRARY
 EXPORTS
 ;
 oggpack_writeinit


### PR DESCRIPTION

Empty LIBRARY statement is valid for MSVC, but MinGW fails with syntax
error.