### PR TITLE
Update the comment in config_types.h.in

### DIFF
--- a/include/ogg/config_types.h.in
+++ b/include/ogg/config_types.h.in
@@ -1,7 +1,7 @@
 #ifndef __CONFIG_TYPES_H__
 #define __CONFIG_TYPES_H__
 
-/* these are filled in by configure */
+/* these are filled in by configure or cmake*/
 #define INCLUDE_INTTYPES_H @INCLUDE_INTTYPES_H@
 #define INCLUDE_STDINT_H @INCLUDE_STDINT_H@
 #define INCLUDE_SYS_TYPES_H @INCLUDE_SYS_TYPES_H@


### PR DESCRIPTION
@var@ is replaced by configure when autoconf or cmake when use cmake