### PR TITLE
Memory leak in test_framing

### DIFF
--- a/src/framing.c
+++ b/src/framing.c
@@ -2099,6 +2099,8 @@ int main(void){
       }
     }
   }
+  ogg_stream_clear(&os_en);
+  ogg_stream_clear(&os_de);
 
   return(0);
 }


### PR DESCRIPTION
We call ogg_stream_init() in main() of framing.c, but no ogg_stream_clear() in corresponding. It will cause memory leak.