### PR TITLE
Fix memory leak in test_framing

### DIFF
--- a/src/framing.c
+++ b/src/framing.c
@@ -2099,6 +2099,7 @@ int main(void){
       }
     }
   }
+  ogg_sync_clear(&oy);
   ogg_stream_clear(&os_en);
   ogg_stream_clear(&os_de);
 


### PR DESCRIPTION
oy.data memory is alloc by ogg_sync_buffer(), but does not calling free() before main() exit. After fixing it, I test test_framing by valgrind. And no more memory leak in test_framing and test_bitwise right now.