### PR TITLE
Add Testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,12 +120,12 @@ Use Makefile generator which is default one.
     cmake .
     make
 
-## Testing
+## Testing ##
 
 This package includes a collection of automated tests.
 Running them is not part of building nor installation but optional. 
 
-### Unix-like
+### Unix-like System or MinGW ###
 
 If build under automake:
 
@@ -139,7 +139,7 @@ or:
 
     ctest
 
-### Windows
+### Windows with MSBuild ###
 
 If build with configuration type "Debug", then:
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,9 @@ Use Makefile generator which is default one.
 
 This package includes a collection of automated tests.
 Running them is not part of building nor installation but optional. 
-And they can only run under UNIX-like system.
+
+### Unix-like
+
 If build under automake:
 
     make check
@@ -136,6 +138,16 @@ If build under CMake:
 or:
 
     ctest
+
+### Windows
+
+If build with configuration type "Debug", then:
+
+    ctest -C Debug
+
+If build with configuration type "Release", then:
+
+    ctest -C Release
 
 ## License ##
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ If build under CMake:
 
     make test
 
+or:
+
+    ctest
+
 ## License ##
 
 THIS FILE IS PART OF THE OggVorbis SOFTWARE CODEC SOURCE CODE.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ Use Makefile generator which is default one.
     cmake .
     make
 
+## Testing
+
+This package includes a collection of automated tests.
+Running them is not part of building nor installation but optional.
+To run the tests:
+
+    make check
+
 ## License ##
 
 THIS FILE IS PART OF THE OggVorbis SOFTWARE CODEC SOURCE CODE.

--- a/README.md
+++ b/README.md
@@ -123,10 +123,15 @@ Use Makefile generator which is default one.
 ## Testing
 
 This package includes a collection of automated tests.
-Running them is not part of building nor installation but optional.
-To run the tests:
+Running them is not part of building nor installation but optional. 
+And they can only run under UNIX-like system.
+If build under automake:
 
     make check
+
+If build under CMake:
+
+    make test
 
 ## License ##
 


### PR DESCRIPTION
Hi, I add self test instruction to README, for I think it is a import part.
In fact, `make check` could not run after building with CMake right now. I will try to add the function under Linux or other possible platform.