### PR TITLE
Verify cmake build works from dist tarballs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,7 @@ pkgconfig_DATA = ogg.pc
 EXTRA_DIST = README.md AUTHORS CHANGES COPYING \
 	libogg.spec libogg.spec.in \
 	ogg.m4 ogg.pc.in ogg-uninstalled.pc.in \
-	macosx win32 CMakeLists.txt cmake/OggConfig.cmake.in
+	macosx win32 CMakeLists.txt cmake
 
 dist-hook:
 	for item in $(EXTRA_DIST); do \

--- a/Makefile.am
+++ b/Makefile.am
@@ -26,6 +26,17 @@ dist-hook:
 	    echo "OK"; \
 	  fi; \
 	done
+
+# Verify cmake works with the dist tarball.
+cmake_builddir = _build.cmake
+distcheck-hook:
+	$(RM) -rf $(cmake_builddir)
+	mkdir $(cmake_builddir)
+	cd $(cmake_builddir) && cmake ../$(top_distdir)
+	cd $(cmake_builddir) && cmake --build .
+	cd $(cmake_builddir) && ctest
+	$(RM) -rf $(cmake_builddir)
+
 debug:
 	$(MAKE) all CFLAGS="@DEBUG@"
 


### PR DESCRIPTION
Add missing CMake build description files to the dist target and try to catch bugs like this in the the future.