### PR TITLE
enabled versioned MinGW-w64 .dlls on cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,12 @@ set_target_properties(
     PUBLIC_HEADER "${OGG_HEADERS}"
 )
 
+if(WIN32)
+    set_target_properties(
+        ogg PROPERTIES
+        RUNTIME_OUTPUT_NAME ogg-${LIB_SOVERSION})
+endif()
+
 if(BUILD_FRAMEWORK)
     set_target_properties(ogg PROPERTIES
         FRAMEWORK TRUE


### PR DESCRIPTION
This enables versioned `.dll` shared libraries on cmake using MinGW-w64, in concurrence with autotools also producing versioned `.dll` shared libraries.