### PR TITLE
os_types: fix unsigned typedefs for MacOS

### DIFF
--- a/include/ogg/os_types.h
+++ b/include/ogg/os_types.h
@@ -72,11 +72,11 @@
 
 #  include <sys/types.h>
    typedef int16_t ogg_int16_t;
-   typedef uint16_t ogg_uint16_t;
+   typedef u_int16_t ogg_uint16_t;
    typedef int32_t ogg_int32_t;
-   typedef uint32_t ogg_uint32_t;
+   typedef u_int32_t ogg_uint32_t;
    typedef int64_t ogg_int64_t;
-   typedef uint64_t ogg_uint64_t;
+   typedef u_int64_t ogg_uint64_t;
 
 #elif defined(__HAIKU__)
 


### PR DESCRIPTION
This effectively reverts f8ce071e1040c766157d630d920d6165d35fe422 which was
probably broken by 6449883ccacfee276ed9d99fa047342cdc51ab88.

See also https://git.xiph.org/?p=opus.git;a=blob;f=include/opus_types.h;h=7cf675580ffb0ad9ba7b040a5c03eb2828910486;hb=HEAD#l93