### PR TITLE
win32/ogg.def: remove LIBRARY directive

### DIFF
--- a/win32/ogg.def
+++ b/win32/ogg.def
@@ -2,7 +2,6 @@
 ; ogg.def
 ; List of exported functions for Windows builds.
 ;
-LIBRARY ogg
 EXPORTS
 ;
 oggpack_writeinit


### PR DESCRIPTION
it is not needed, and it caused wrong import lib generation with cmake.