### PR TITLE
os_types.h: Properly define types on macOS

### DIFF
--- a/include/ogg/os_types.h
+++ b/include/ogg/os_types.h
@@ -71,6 +71,7 @@
 #elif (defined(__APPLE__) && defined(__MACH__)) /* MacOS X Framework build */
 
 #  include <sys/types.h>
+#  include <stdint.h>
    typedef int16_t ogg_int16_t;
    typedef u_int16_t ogg_uint16_t;
    typedef int32_t ogg_int32_t;


### PR DESCRIPTION
Hello!

I was trying to build `ogg` `vorbis` `flac` `opus` and `sndfile` libraries for macOS. Unfortunately, with more recent builds of the macOS operating systems, it seemed that some includes were missing.

Digging deeper into the problem, I found that actually the culprit was `os_types.h`, not including `<stdint.h>`.
Adding the include fixed the issue.

ogg was built using `cmake` on a Big Sur macOS and latest XCode tools.