### PR TITLE
Workaround for config_types.h.in to use CMake and configure side-by-side

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,10 +50,25 @@ endfunction()
 
 message(STATUS "Configuring ${PROJECT_NAME} ${PROJECT_VERSION}")
 
-# Configure config_type.h
-check_include_files(inttypes.h INCLUDE_INTTYPES_H)
-check_include_files(stdint.h INCLUDE_STDINT_H)
-check_include_files(sys/types.h INCLUDE_SYS_TYPES_H)
+# Configure config_type.h (workaround to work both configure and cmake)
+set(INCLUDE_INTTYPES_H 0)
+set(INCLUDE_STDINT_H 0)
+set(INCLUDE_SYS_TYPES_H 0)
+check_include_files(inttypes.h INCLUDE_INTTYPES_H_)
+check_include_files(stdint.h INCLUDE_STDINT_H_)
+check_include_files(sys/types.h INCLUDE_SYS_TYPES_H_)
+
+if(INCLUDE_INTTYPES_H_ EQUAL 1)
+    set(INCLUDE_INTTYPES_H 1)
+endif()
+
+if(INCLUDE_STDINT_H_ EQUAL 1)
+    set(INCLUDE_STDINT_H 1)
+endif()
+
+if(INCLUDE_SYS_TYPES_H_ EQUAL 1)
+    set(INCLUDE_SYS_TYPES_H 1)
+endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 set(SIZE16 int16_t)


### PR DESCRIPTION
Init INCLUDE_INTTYPES_H, INCLUDE_STDINT_H, INCLUDE_SYS_TYPES_H, CMake variables as 0

It is need to prevent generate broken code in config_types.h
So next code was genarated before (e.g. for Android SDK)
```
#define INCLUDE_INTTYPES_H
...
#if INCLUDE_INTTYPES_H
...
#endif
```
And got `error: expected value in expression` (in third line)


After this changes code will be
```
#define INCLUDE_INTTYPES_H 0
...
#if INCLUDE_INTTYPES_H
...
#endif
```


This changes seems like a smelt code, but it need to compatibility with `configure` script
To avoid this workaround we can use cmake-specific directive `#cmakedefine01`  in `config_types.h.in` [configure_file man](https://cmake.org/cmake/help/latest/command/configure_file.html)