### PR TITLE
Remove CTest include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,6 @@ project(ogg VERSION ${CMAKE_MATCH_1} LANGUAGES C)
 include(GNUInstallDirs)
 include(CheckIncludeFiles)
 include(CMakePackageConfigHelpers)
-include(CTest)
 
 # Build options
 option(BUILD_SHARED_LIBS "Build shared library" OFF)


### PR DESCRIPTION
Without this include, CTest can still be run. Removing this cleans up MSVC solution explorer, as CTestDashboardTargets (Continuous, Experimental, Nightly and NightlyMemoryCheck) no longer show up