### PR TITLE
Function for querying the Ogg library's version

### DIFF
--- a/include/ogg/ogg.h
+++ b/include/ogg/ogg.h
@@ -201,6 +201,7 @@ extern int      ogg_page_packets(const ogg_page *og);
 
 extern void     ogg_packet_clear(ogg_packet *op);
 
+extern const char *ogg_version_string(void);
 
 #ifdef __cplusplus
 }

--- a/src/framing.c
+++ b/src/framing.c
@@ -28,6 +28,8 @@
 #include <string.h>
 #include <ogg/ogg.h>
 
+#define GENERAL_VENDOR_STRING "Xiph.Org libOgg 1.3.6"
+
 /* A complete description of Ogg framing exists in docs/framing.html */
 
 int ogg_page_version(const ogg_page *og){
@@ -1004,6 +1006,10 @@ int ogg_stream_packetpeek(ogg_stream_state *os,ogg_packet *op){
 void ogg_packet_clear(ogg_packet *op) {
   _ogg_free(op->packet);
   memset(op, 0, sizeof(*op));
+}
+
+const char *ogg_version_string(void){
+  return GENERAL_VENDOR_STRING;
 }
 
 #ifdef _V_SELFTEST


### PR DESCRIPTION
I noticed that many other Xiph libraries such as libvorbis and libopus have a means of querying for version information.

This pull request adds a function to the ogg library that allows developers to also query for the version of the Ogg library.

It is named `ogg_version_string()` to mimic libvorbis's naming scheme (my attempt to keep naming consistent across projects).

